### PR TITLE
Load the package scaffold command by default

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+require:
+  - command.php


### PR DESCRIPTION
Useful when it's not required globally, but you're working with it locally