### PR TITLE
Use the package long name when generating the readme

### DIFF
--- a/templates/readme.mustache
+++ b/templates/readme.mustache
@@ -1,4 +1,4 @@
-{{package_short_name}}
+{{package_name}}
 {{package_name_border}}
 
 {{package_description}}


### PR DESCRIPTION
It's easier to copy and paste into the installer