### PR TITLE
Ignore wp-cli.local.yml in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 composer.lock
+wp-cli.local.yml
 node_modules/
 vendor/


### PR DESCRIPTION
This file is only ever meant for local development