### PR TITLE
Support specifying required WP-CLI version in composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package implements the following commands:
 Generate the files needed for a basic WP-CLI command.
 
 ~~~
-wp scaffold package <name> [--description=<description>] [--homepage=<homepage>] [--dir=<dir>] [--license=<license>] [--skip-tests] [--skip-readme] [--force]
+wp scaffold package <name> [--description=<description>] [--homepage=<homepage>] [--dir=<dir>] [--license=<license>] [--require_wp_cli=<version>] [--skip-tests] [--skip-readme] [--force]
 ~~~
 
 Default behavior is to create the following files:
@@ -45,6 +45,12 @@ WP-CLI package directory.
 
 	[--license=<license>]
 		License for the package. Default: MIT.
+
+	[--require_wp_cli=<version>]
+		Required WP-CLI version for the package.
+		---
+		default: ~0.23.0
+		---
 
 	[--skip-tests]
 		Don't generate files for integration testing.

--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -9,3 +9,27 @@ Feature: Scaffold a README.md file for an existing package
       Success: Created package readme.
       """
     And the foo/README.md file should exist
+    And the foo/README.md file should contain:
+      """
+      Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
+      """
+
+  Scenario: Scaffold a README.md requiring a nightly build
+    Given an empty directory
+
+    When I run `wp scaffold package wp-cli/foo --dir=foo --require_wp_cli='~0.24.0-alpha'`
+    Then STDOUT should contain:
+      """
+      Success: Created package readme.
+      """
+    And the foo/composer.json file should contain:
+      """
+          "require": {
+              "wp-cli/wp-cli": "~0.24.0-alpha"
+          },
+      """
+    And the foo/README.md file should exist
+    And the foo/README.md file should contain:
+      """
+      Installing this package requires WP-CLI v0.24.0-alpha or greater. Update to the latest nightly release with `wp cli update --nightly`.
+      """

--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -15,6 +15,12 @@ Feature: Scaffold WP-CLI commands
       """
       "homepage": "https://github.com/wp-cli/foo",
       """
+    And the packages/vendor/wp-cli/foo/composer.json file should contain:
+      """
+          "require": {
+              "wp-cli/wp-cli": "~0.23.0"
+          },
+      """
     And the packages/vendor/wp-cli/foo/command.php file should exist
     And the packages/vendor/wp-cli/foo/wp-cli.yml file should exist
     And the packages/vendor/wp-cli/foo/.travis.yml file should not exist

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -147,9 +147,16 @@ class ScaffoldPackageCommand {
 			'package_short_name'  => $bits[1],
 			'package_name_border' => str_pad( '', strlen( $composer_obj['name'] ), '=' ),
 			'package_description' => $composer_obj['description'],
+			'required_wp_cli_version' => ! empty( $composer_obj['require']['wp-cli/wp-cli'] ) ? str_replace( '~', '', $composer_obj['require']['wp-cli/wp-cli'] ) : 'v0.23.0',
 			'has_travis'          => file_exists( $package_dir . '/.travis.yml' ),
 			'has_commands'        => false,
 		);
+
+		if ( false !== stripos( $readme_args['required_wp_cli_version'], 'alpha' ) ) {
+			$readme_args['wp_cli_update_to_instructions'] = 'the latest nightly release with `wp cli update --nightly`';
+		} else {
+			$readme_args['wp_cli_update_to_instructions'] = 'the latest stable release with `wp cli update`';
+		}
 
 		if ( ! empty( $composer_obj['extras']['commands'] ) ) {
 			$readme_args['commands'] = array();

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -38,6 +38,12 @@ class ScaffoldPackageCommand {
 	 * [--license=<license>]
 	 * : License for the package. Default: MIT.
 	 *
+	 * [--require_wp_cli=<version>]
+	 * : Required WP-CLI version for the package.
+	 * ---
+	 * default: ~0.23.0
+	 * ---
+	 *
 	 * [--skip-tests]
 	 * : Don't generate files for integration testing.
 	 *
@@ -147,7 +153,7 @@ class ScaffoldPackageCommand {
 			'package_short_name'  => $bits[1],
 			'package_name_border' => str_pad( '', strlen( $composer_obj['name'] ), '=' ),
 			'package_description' => $composer_obj['description'],
-			'required_wp_cli_version' => ! empty( $composer_obj['require']['wp-cli/wp-cli'] ) ? str_replace( '~', '', $composer_obj['require']['wp-cli/wp-cli'] ) : 'v0.23.0',
+			'required_wp_cli_version' => ! empty( $composer_obj['require']['wp-cli/wp-cli'] ) ? str_replace( '~', 'v', $composer_obj['require']['wp-cli/wp-cli'] ) : 'v0.23.0',
 			'has_travis'          => file_exists( $package_dir . '/.travis.yml' ),
 			'has_commands'        => false,
 		);

--- a/templates/composer.mustache
+++ b/templates/composer.mustache
@@ -9,7 +9,7 @@
         "files": [ "command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "~0.23.0"
+        "wp-cli/wp-cli": "{{require_wp_cli}}"
     },
     "require-dev": {
         "behat/behat": "~2.5"

--- a/templates/composer.mustache
+++ b/templates/composer.mustache
@@ -8,7 +8,9 @@
     "autoload": {
         "files": [ "command.php" ]
     },
-    "require": {},
+    "require": {
+        "wp-cli/wp-cli": "~0.23.0"
+    },
     "require-dev": {
         "behat/behat": "~2.5"
     }

--- a/templates/readme.mustache
+++ b/templates/readme.mustache
@@ -33,7 +33,7 @@ This package implements the following commands:
 {{/has_commands}}
 ## Installing
 
-Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
+Installing this package requires WP-CLI {{required_wp_cli_version}} or greater. Update to {{wp_cli_update_to_instructions}}.
 
 Once you've done so, you can install this package with `wp package install {{package_name}}`.
 


### PR DESCRIPTION
This should be automatically reflected in the README's Installing
section