### PR TITLE
Run Behat in strict mode in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ env:
 before_script:
   - bash bin/install-package-tests.sh
 
-script: ./vendor/bin/behat
+script: ./vendor/bin/behat --strict

--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,4 @@ test:
   pre:
     - bash bin/install-package-tests.sh
   override:
-    - ./vendor/bin/behat
+    - ./vendor/bin/behat --strict


### PR DESCRIPTION
Doing so ensures any undefined steps will fail the build.