### PR TITLE
Loosen restriction on wp-cli core version

### DIFF
--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -27,7 +27,7 @@ Feature: Scaffold WP-CLI commands
     And the packages/vendor/wp-cli/foo/composer.json file should contain:
       """
           "require": {
-              "wp-cli/wp-cli": "~0.23.0"
+              "wp-cli/wp-cli": "^0.23.0"
           },
       """
     And the packages/vendor/wp-cli/foo/command.php file should exist

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -172,7 +172,7 @@ class ScaffoldPackageCommand {
 			'package_short_name'  => $bits[1],
 			'package_name_border' => str_pad( '', strlen( $composer_obj['name'] ), '=' ),
 			'package_description' => $composer_obj['description'],
-			'required_wp_cli_version' => ! empty( $composer_obj['require']['wp-cli/wp-cli'] ) ? str_replace( '~', 'v', $composer_obj['require']['wp-cli/wp-cli'] ) : 'v0.23.0',
+			'required_wp_cli_version' => ! empty( $composer_obj['require']['wp-cli/wp-cli'] ) ? str_replace( array( '~', '^' ), 'v', $composer_obj['require']['wp-cli/wp-cli'] ) : 'v0.23.0',
 			'shields'             => '',
 			'has_commands'        => false,
 			'wp_cli_update_to_instructions' => 'the latest stable release with `wp cli update`',

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -44,7 +44,7 @@ class ScaffoldPackageCommand {
 	 * [--require_wp_cli=<version>]
 	 * : Required WP-CLI version for the package.
 	 * ---
-	 * default: ~0.23.0
+	 * default: ^0.23.0
 	 * ---
 	 *
 	 * [--skip-tests]


### PR DESCRIPTION
The current default required WP-CLI version should be satisfied by `0.24` and any other pre 1.0 release.