### PR TITLE
Composer Schema compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
 
 before_script:
+  - composer validate --strict
   - bash bin/install-package-tests.sh
 
 script: ./vendor/bin/behat --strict

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ WP-CLI package directory.
 	[--require_wp_cli=<version>]
 		Required WP-CLI version for the package.
 		---
-		default: ~0.23.0
+		default: ^0.23.0
 		---
 
 	[--skip-tests]
@@ -168,14 +168,14 @@ based on the composer.json file for your WP-CLI package. Run this command
 at the beginning of your project, and then every time your usage docs
 change.
 
-These command-specific docs are generated based composer.json -> 'extras'
+These command-specific docs are generated based composer.json -> 'extra'
 -> 'commands'. For instance, this package's composer.json includes:
 
 ```
 {
   "name": "wp-cli/scaffold-package-command",
    // [...]
-   "extras": {
+   "extra": {
        "commands": [
            "scaffold package",
            "scaffold package-tests",

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
 
 test:
   pre:
+    - composer validate --strict
     - bash bin/install-package-tests.sh
   override:
     - ./vendor/bin/behat --strict

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "behat/behat": "~2.5"
     },
-    "extras": {
+    "extra": {
         "commands": [
             "scaffold package",
             "scaffold package-tests",

--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -58,7 +58,7 @@ Feature: Scaffold a README.md file for an existing package
           "require-dev": {
               "behat/behat": "~2.5"
           },
-          "extras": {
+          "extra": {
               "readme": {
                   "shields": [
                     "[![CircleCI](https://circleci.com/gh/runcommand/profile/tree/master.svg?style=svg&circle-token=d916e588bf7c8ac469a3bd01930cf9eed886debe)](https://circleci.com/gh/runcommand/profile/tree/master)"
@@ -83,7 +83,7 @@ Feature: Scaffold a README.md file for an existing package
           "name": "runcommand/profile",
           "description": "Quickly identify what's slow with WordPress.",
           "homepage": "https://runcommand.io/wp/profile/",
-          "extras": {
+          "extra": {
               "readme": {
                   "contributing": {
                     "body": "https://gist.githubusercontent.com/danielbachhuber/bb652b1b744cea541705ee9c13605dad/raw/195c17ebb8cf25e947a9df6e02de1e96a084c287/support.md"
@@ -110,7 +110,7 @@ Feature: Scaffold a README.md file for an existing package
           "name": "runcommand/profile",
           "description": "Quickly identify what's slow with WordPress.",
           "homepage": "https://runcommand.io/wp/profile/",
-          "extras": {
+          "extra": {
               "readme": {
                   "sections": [
                     "Installing",

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -120,14 +120,14 @@ class ScaffoldPackageCommand {
 	 * at the beginning of your project, and then every time your usage docs
 	 * change.
 	 *
-	 * These command-specific docs are generated based composer.json -> 'extras'
+	 * These command-specific docs are generated based composer.json -> 'extra'
 	 * -> 'commands'. For instance, this package's composer.json includes:
 	 *
 	 * ```
 	 * {
 	 *   "name": "wp-cli/scaffold-package-command",
 	 *    // [...]
-	 *    "extras": {
+	 *    "extra": {
 	 *        "commands": [
 	 *            "scaffold package",
 	 *            "scaffold package-tests",
@@ -178,8 +178,8 @@ class ScaffoldPackageCommand {
 			'wp_cli_update_to_instructions' => 'the latest stable release with `wp cli update`',
 		);
 
-		if ( isset( $composer_obj['extras']['readme']['shields'] ) ) {
-			$readme_args['shields'] = implode( ' ', $composer_obj['extras']['readme']['shields'] );
+		if ( isset( $composer_obj['extra']['readme']['shields'] ) ) {
+			$readme_args['shields'] = implode( ' ', $composer_obj['extra']['readme']['shields'] );
 		} else {
 			$shields = array();
 			if ( file_exists( $package_dir . '/.travis.yml' ) ) {
@@ -198,13 +198,13 @@ class ScaffoldPackageCommand {
 			$readme_args['wp_cli_update_to_instructions'] = 'the latest nightly release with `wp cli update --nightly`';
 		}
 
-		if ( ! empty( $composer_obj['extras']['commands'] ) ) {
+		if ( ! empty( $composer_obj['extra']['commands'] ) ) {
 			$readme_args['commands'] = array();
 			ob_start();
 			WP_CLI::run_command( array( 'cli', 'cmd-dump' ) );
 			$ret = ob_get_clean();
 			$cmd_dump = json_decode( $ret, true );
-			foreach( $composer_obj['extras']['commands'] as $command ) {
+			foreach( $composer_obj['extra']['commands'] as $command ) {
 				$bits = explode( ' ', $command );
 				$parent_command = $cmd_dump;
 				do {
@@ -239,8 +239,8 @@ class ScaffoldPackageCommand {
 			$readme_args['has_multiple_commands'] = count( $readme_args['commands'] ) > 1 ? true : false;
 		}
 
-		if ( isset( $composer_obj['extras']['readme']['sections'] ) ) {
-			$readme_section_headings = $composer_obj['extras']['readme']['sections'];
+		if ( isset( $composer_obj['extra']['readme']['sections'] ) ) {
+			$readme_section_headings = $composer_obj['extra']['readme']['sections'];
 		} else {
 			$readme_section_headings = array(
 				'Using',
@@ -282,8 +282,8 @@ class ScaffoldPackageCommand {
 			$value = array();
 			foreach( array( 'pre', 'body', 'post' ) as $k ) {
 				$v = '';
-				if ( isset( $composer_obj['extras']['readme'][ $section ][ $k ] ) ) {
-					$v = $composer_obj['extras']['readme'][ $section][ $k ];
+				if ( isset( $composer_obj['extra']['readme'][ $section ][ $k ] ) ) {
+					$v = $composer_obj['extra']['readme'][ $section][ $k ];
 					if ( false !== stripos( $v, '://' ) ) {
 						$response = Utils\http_request( 'GET', $v );
 						$v = $response->body;


### PR DESCRIPTION
The current implementation using the `"extras"` key in `composer.json` is not valid according to the [`composer.json` schema](https://getcomposer.org/doc/04-schema.md#extra).

**Exhibit A**

![image](https://cloud.githubusercontent.com/assets/1621608/18615012/ce07244a-7dab-11e6-8f51-1cf535fecb49.png)

The proper key to use is `"extra"` (singular).

Fortunately, this key is not part of the `composer.mustache` template for a new package, but users (like myself) might be very confused when trying to leverage the options within for readme generation and your IDE starts yelling at you that it's broken.

This PR corrects all references to use the correct schema, and adds validation checks to the build to ensure it doesn't get out of sync in the future.

Related #42 