### PR TITLE
Rendering multiple shields

### DIFF
--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -61,7 +61,9 @@ Feature: Scaffold a README.md file for an existing package
           "extra": {
               "readme": {
                   "shields": [
-                    "[![CircleCI](https://circleci.com/gh/runcommand/profile/tree/master.svg?style=svg&circle-token=d916e588bf7c8ac469a3bd01930cf9eed886debe)](https://circleci.com/gh/runcommand/profile/tree/master)"
+                    "shield 1",
+                    "shield 2",
+                    "shield 3"
                   ]
               }
           }
@@ -72,7 +74,9 @@ Feature: Scaffold a README.md file for an existing package
     Then the foo/README.md file should exist
     And the foo/README.md file should contain:
       """
-      tree/master.svg?style=svg&circle-token=
+      shield 1
+      shield 2
+      shield 3
       """
 
   Scenario: Scaffold a readme with a remote support body

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -179,7 +179,7 @@ class ScaffoldPackageCommand {
 		);
 
 		if ( isset( $composer_obj['extra']['readme']['shields'] ) ) {
-			$readme_args['shields'] = implode( ' ', $composer_obj['extra']['readme']['shields'] );
+			$readme_args['shields'] = implode( "\n", $composer_obj['extra']['readme']['shields'] );
 		} else {
 			$shields = array();
 			if ( file_exists( $package_dir . '/.travis.yml' ) ) {
@@ -190,7 +190,7 @@ class ScaffoldPackageCommand {
 			}
 
 			if ( count( $shields ) ) {
-				$readme_args['shields'] = implode( ' ', $shields );
+				$readme_args['shields'] = implode( "\n", $shields );
 			}
 		}
 


### PR DESCRIPTION
Currently when scaffolding a readme which has multiple shields defined in the `composer.json`, the rendered result is one single long line in the `README.md`.

This PR changes that so that they are rendered on their own line in markdown, but still display the same way as one would expect - as a single horizontal "chain" of shields.