### PR TITLE
Test both WordPress latest and trunk on Circle builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,4 +13,6 @@ test:
     - composer validate --strict
     - bash bin/install-package-tests.sh
   override:
-    - ./vendor/bin/behat --strict
+    - WP_VERSION=latest ./vendor/bin/behat --strict
+    - rm -rf '/tmp/wp-cli-test core-download-cache'
+    - WP_VERSION=trunk ./vendor/bin/behat --strict


### PR DESCRIPTION
Circle doesn't have an equivalent test matrix, so let's test these two
variants at the very least.