### PR TITLE
Error when generating README for missing command

### DIFF
--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -167,3 +167,25 @@ Feature: Scaffold a README.md file for an existing package
       """
       *This README.md is generated dynamically from the project's codebase
       """
+
+  Scenario: Error when commands are specified but not present
+    Given an empty directory
+    And a foo/composer.json file:
+      """
+      {
+          "name": "runcommand/profile",
+          "description": "Quickly identify what's slow with WordPress.",
+          "homepage": "https://runcommand.io/wp/profile/",
+          "extra": {
+              "commands": [
+                "profile"
+              ]
+          }
+      }
+      """
+
+    When I try `wp scaffold package-readme foo`
+    Then STDERR should be:
+      """
+      Error: Missing one or more commands defined in composer.json -> extras -> commands.
+      """

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -223,6 +223,10 @@ class ScaffoldPackageCommand {
 					}
 				} while( $parent_command && $bits );
 
+				if ( empty( $parent_command ) ) {
+					WP_CLI::error( 'Missing one or more commands defined in composer.json -> extras -> commands.' );
+				}
+
 				$longdesc = preg_replace( '/## GLOBAL PARAMETERS(.+)/s', '', $parent_command['longdesc'] );
 				$longdesc = preg_replace( '/##\s(.+)/', '**$1**', $longdesc );
 


### PR DESCRIPTION
This is a less confusing error than having usage instructions missing
from the README