### PR TITLE
Don't validate `composer.json` strictly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
 
 before_script:
-  - composer validate --strict
+  - composer validate
   - bash bin/install-package-tests.sh
 
 script: ./vendor/bin/behat --strict

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
 
 test:
   pre:
-    - composer validate --strict
+    - composer validate
     - bash bin/install-package-tests.sh
   override:
     - WP_VERSION=latest ./vendor/bin/behat --strict


### PR DESCRIPTION
`--strict` means Composer will complain about warnings in a hard way.
Given we're producing a `composer.json` that has warnings, we don't want
builds to fail.

```
local ➜  assign-featured-images git:(master) composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
require.wp-cli/wp-cli : unbound version constraints (>=0.23.0) should be avoided
local ➜  assign-featured-images git:(master) echo $?
0
local ➜  assign-featured-images git:(master) composer validate --strict
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
require.wp-cli/wp-cli : unbound version constraints (>=0.23.0) should be avoided
local ➜  assign-featured-images git:(master) echo $?
1
```

See #46, #55