### PR TITLE
Include "type": "wp-cli-package" when scaffolding a new command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "wp-cli/scaffold-package-command",
     "description": "Scaffold WP-CLI commands with functional tests",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/scaffold-package-command",
     "support": {
         "issues": "https://github.com/wp-cli/scaffold-package-command/issues"

--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -18,6 +18,10 @@ Feature: Scaffold WP-CLI commands
     And the packages/vendor/wp-cli/foo/composer.json file should exist
     And the packages/vendor/wp-cli/foo/composer.json file should contain:
       """
+      "type": "wp-cli-package",
+      """
+    And the packages/vendor/wp-cli/foo/composer.json file should contain:
+      """
       "homepage": "https://github.com/wp-cli/foo",
       """
     And the packages/vendor/wp-cli/foo/composer.json file should contain:

--- a/templates/composer.mustache
+++ b/templates/composer.mustache
@@ -1,6 +1,7 @@
 {
     "name": "{{name}}",
     "description": "{{description}}",
+    "type": "wp-cli-package",
     "homepage": "{{homepage}}",
     "license": "{{license}}",
     "authors": [],


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567