### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "wp-cli/scaffold-package-command",
     "description": "Scaffold WP-CLI commands with functional tests",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/scaffold-package-command",
     "support": {
         "issues": "https://github.com/wp-cli/scaffold-package-command/issues"


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567