### PR TITLE
Don't render shields on newlines

### DIFF
--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -78,9 +78,7 @@ Feature: Scaffold a README.md file for an existing package
     Then the foo/README.md file should exist
     And the foo/README.md file should contain:
       """
-      shield 1
-      shield 2
-      shield 3
+      shield 1 shield 2 shield 3
       """
 
   Scenario: Scaffold a readme with a remote support body

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -215,7 +215,7 @@ class ScaffoldPackageCommand {
 		);
 
 		if ( isset( $composer_obj['extra']['readme']['shields'] ) ) {
-			$readme_args['shields'] = implode( "\n", $composer_obj['extra']['readme']['shields'] );
+			$readme_args['shields'] = implode( ' ', $composer_obj['extra']['readme']['shields'] );
 		} else {
 			$shields = array();
 			if ( file_exists( $package_dir . '/.travis.yml' ) ) {
@@ -226,7 +226,7 @@ class ScaffoldPackageCommand {
 			}
 
 			if ( count( $shields ) ) {
-				$readme_args['shields'] = implode( "\n", $shields );
+				$readme_args['shields'] = implode( ' ', $shields );
 			}
 		}
 


### PR DESCRIPTION
Not all markdown parsers put these in the same paragraph