### PR TITLE
allow environment variables in feature context

### DIFF
--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -44,7 +44,9 @@ class Process {
 		$command = preg_replace_callback( '/\$([A-Z_]+)/', function( $matches ){
 			$cmd = $matches[0];
 			foreach ( array_slice( $matches, 1 ) as $key ) {
-				$cmd = str_replace( '$' . $key, escapeshellarg( getenv( $key ) ), $cmd );
+				if ( getenv( $key ) ) {
+					$cmd = str_replace( '$' . $key, escapeshellarg( getenv( $key ) ), $cmd );
+				}
 			}
 			return $cmd;
 		}, $this->command );

--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -40,7 +40,16 @@ class Process {
 			2 => array( 'pipe', 'w' ),
 		);
 
-		$proc = proc_open( $this->command, $descriptors, $pipes, $cwd, $this->env );
+		// Convert environment variables.
+		$command = preg_replace_callback( '/\$([A-Z_]+)/', function( $matches ){
+			$cmd = $matches[0];
+			foreach ( array_slice( $matches, 1 ) as $key ) {
+				$cmd = str_replace( '$' . $key, escapeshellarg( getenv( $key ) ), $cmd );
+			}
+			return $cmd;
+		}, $this->command );
+
+		$proc = proc_open( $command, $descriptors, $pipes, $cwd, $this->env );
 
 		$stdout = stream_get_contents( $pipes[1] );
 		fclose( $pipes[1] );


### PR DESCRIPTION
I sometimes want to use environment variables and they are often secret value in feature context like following.

```
When I run `wp foo --api=$MY_VAR`
```

It allows us to use environment variables such as `travis encrypt MY_VAR=secret`.
When the context fails by network problem or so, the log will be displayed like following and environment variables are not displayed.

```
When I run `wp foo --api=$MY_VAR`

  $ wp foo --api=$MY_VAR

      Error: Incorrect ...
      cwd: /var/folders/r8/93smf9ld3lgdsn7ly3s5hj940000gr/T/wp-cli-test-run-58724a4a4d7cf9.38299956/
      exit status: 1
```
