### PR TITLE
Add PHP 7.0 and 7.1 to Travis CI job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ branches:
     - master
 
 php:
-  - 5.3
+  - 7.1
+  - 7.0
   - 5.6
+  - 5.3
 
 cache:
   - composer


### PR DESCRIPTION
Reorders the PHP versions so the newest version which is typically the fastest version of PHP is first