### PR TITLE
Run Behat with `--format progress`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ before_script:
   - composer validate
   - bash bin/install-package-tests.sh
 
-script: ./vendor/bin/behat --strict
+script: ./vendor/bin/behat --format progress --strict

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,6 @@ test:
     - composer validate
     - bash bin/install-package-tests.sh
   override:
-    - WP_VERSION=latest ./vendor/bin/behat --strict
+    - WP_VERSION=latest ./vendor/bin/behat --format progress --strict
     - rm -rf '/tmp/wp-cli-test core-download-cache'
-    - WP_VERSION=trunk ./vendor/bin/behat --strict
+    - WP_VERSION=trunk ./vendor/bin/behat --format progress --strict


### PR DESCRIPTION
On projects with lots of tests, Behat's normal format makes it difficult
to identify the failing tests. `--format progress` makes it easy to
pinpoint the failing tests.