### PR TITLE
Install WP-CLI for tests via `composer require`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ cache:
 
 env:
   global:
-    - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+    - PATH="$HOME/.composer/vendor/bin:$PATH"
+    - WP_CLI_BIN_DIR=$HOME/.composer/vendor/bin
 
 matrix:
   include:
@@ -32,9 +33,14 @@ matrix:
     - php: 5.3
       env: WP_VERSION=latest
 
-before_script:
+install:
   - phpenv config-rm xdebug.ini
-  - composer validate
+  - composer global require wp-cli/wp-cli
+  - composer install --no-dev
   - bash bin/install-package-tests.sh
 
-script: ./vendor/bin/behat --format progress --strict
+before_script:
+  - composer validate
+
+script:
+  - behat --format progress --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
 
 install:
   - phpenv config-rm xdebug.ini
-  - composer global require wp-cli/wp-cli
+  - composer global require wp-cli/wp-cli:dev-master --dev
   - composer install --no-dev
   - bash bin/install-package-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 env:
   global:
     - PATH="$HOME/.composer/vendor/bin:$PATH"
-    - WP_CLI_BIN_DIR=$HOME/.composer/vendor/bin
+    - WP_CLI_BIN_DIR="$HOME/.composer/vendor/bin"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ cache:
 
 env:
   global:
-    - PATH="$HOME/.composer/vendor/bin:$PATH"
-    - WP_CLI_BIN_DIR="$HOME/.composer/vendor/bin"
+    - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+    - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
 
 matrix:
   include:
@@ -33,11 +33,11 @@ matrix:
     - php: 5.3
       env: WP_VERSION=latest
 
-install:
+before_install:
   - phpenv config-rm xdebug.ini
-  - composer global require wp-cli/wp-cli:dev-master
-  - composer global require behat/behat:~2.5
-  - composer install --no-dev
+
+install:
+  - composer install
   - bash bin/install-package-tests.sh
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ matrix:
 
 install:
   - phpenv config-rm xdebug.ini
-  - composer global require wp-cli/wp-cli:dev-master --dev
+  - composer global require wp-cli/wp-cli:dev-master
+  - composer global require behat/behat:~2.5
   - composer install --no-dev
   - bash bin/install-package-tests.sh
 

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -2,39 +2,9 @@
 
 set -ex
 
-WP_CLI_BIN_DIR=${WP_CLI_BIN_DIR-/tmp/wp-cli-phar}
-
-PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
-
-download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
-}
-
-install_wp_cli() {
-
-	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
-	mkdir -p $WP_CLI_BIN_DIR
-	download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
-	chmod +x $WP_CLI_BIN_DIR/wp
-
-}
-
-download_behat() {
-
-	cd $PACKAGE_DIR
-	composer require --dev behat/behat='~2.5'
-
-}
-
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
-install_wp_cli
-download_behat
 install_db

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
     # Increase memory limit
     - echo "memory_limit = 512M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
   override:
-    - composer global require wp-cli/wp-cli
+    - composer global require wp-cli/wp-cli:dev-master --dev
     - composer install --no-dev
     - bash bin/install-package-tests.sh
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
 
 dependencies:
   cache_directories:
-    - $HOME/.composer/cache
+    - ~/.composer/cache
   pre:
     # Set the PHP timezone so that Behat does not fail.
     - echo "date.timezone = 'US/Central'" > /opt/circleci/php/$(phpenv global)/etc/conf.d/wp-cli-timezone.ini

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,8 @@ dependencies:
     # Increase memory limit
     - echo "memory_limit = 512M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
   override:
-    - composer global require wp-cli/wp-cli:dev-master --dev
+    - composer global require wp-cli/wp-cli:dev-master
+    - composer global require behat/behat:~2.5
     - composer install --no-dev
     - bash bin/install-package-tests.sh
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ machine:
   php:
     version: 5.6.22
   environment:
-    PATH: "$HOME/.composer/vendor/bin:$PATH"
-    WP_CLI_BIN_DIR: "$HOME/.composer/vendor/bin"
+    PATH: "$HOME/$CIRCLE_PROJECT_REPONAME/vendor/bin:$PATH"
+    WP_CLI_BIN_DIR: "$HOME/$CIRCLE_PROJECT_REPONAME/vendor/bin"
 
 dependencies:
   cache_directories:
-    - ~/.composer/cache
+    - $HOME/.composer/cache
   pre:
     # Set the PHP timezone so that Behat does not fail.
     - echo "date.timezone = 'US/Central'" > /opt/circleci/php/$(phpenv global)/etc/conf.d/wp-cli-timezone.ini
@@ -16,9 +16,7 @@ dependencies:
     # Increase memory limit
     - echo "memory_limit = 512M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
   override:
-    - composer global require wp-cli/wp-cli:dev-master
-    - composer global require behat/behat:~2.5
-    - composer install --no-dev
+    - composer install
     - bash bin/install-package-tests.sh
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,8 @@ machine:
   php:
     version: 5.6.22
   environment:
-    WP_CLI_BIN_DIR: /tmp/wp-cli-phar
+    PATH: "$HOME/.composer/vendor/bin:$PATH"
+    WP_CLI_BIN_DIR: "$HOME/.composer/vendor/bin"
 
 dependencies:
   cache_directories:
@@ -14,13 +15,15 @@ dependencies:
     - echo ""  > /opt/circleci/php/$(phpenv global)/etc/conf.d/xdebug.ini
     # Increase memory limit
     - echo "memory_limit = 512M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
-
+  override:
+    - composer global require wp-cli/wp-cli
+    - composer install --no-dev
+    - bash bin/install-package-tests.sh
 
 test:
   pre:
     - composer validate
-    - bash bin/install-package-tests.sh
   override:
-    - WP_VERSION=latest ./vendor/bin/behat --format progress --strict
+    - WP_VERSION=latest behat --format progress --strict
     - rm -rf '/tmp/wp-cli-test core-download-cache'
-    - WP_VERSION=trunk ./vendor/bin/behat --format progress --strict
+    - WP_VERSION=trunk behat --format progress --strict

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
     "autoload": {
         "files": [ "command.php" ]
     },
-    "require": {},
+    "require": {
+        "wp-cli/wp-cli": "~1.0.0"
+    },
     "require-dev": {
         "behat/behat": "~2.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "files": [ "command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "~1.0.0"
+        "wp-cli/wp-cli": "^1.0.0"
     },
     "require-dev": {
         "behat/behat": "~2.5"


### PR DESCRIPTION
Doing so makes `utils/make-phar.php` available to the test suite.

Because WP-CLI will come with Behat, it's not longer necessary to
install via `install-package-tests.sh` or the package's dependencies.

See https://github.com/wp-cli/package-command/issues/1
Fixes #88