### PR TITLE
Use `^` caret operator for default WP-CLI version

### DIFF
--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -34,7 +34,7 @@ Feature: Scaffold WP-CLI commands
     And the {PACKAGE_PATH}/local/wp-cli/foo/composer.json file should contain:
       """
           "require": {
-              "wp-cli/wp-cli": ">=1.1.0"
+              "wp-cli/wp-cli": "^1.1.0"
           },
       """
     And the {PACKAGE_PATH}/local/wp-cli/foo/command.php file should exist

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -44,7 +44,7 @@ class ScaffoldPackageCommand {
 	 * [--require_wp_cli=<version>]
 	 * : Required WP-CLI version for the package.
 	 * ---
-	 * default: >=1.1.0
+	 * default: ^1.1.0
 	 * ---
 	 *
 	 * [--skip-tests]


### PR DESCRIPTION
`^1.0.0` is functionally equivalent to `>=1.0.0`