### PR TITLE
Require minimum stable version, then install `dev-master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 install:
+  - composer require wp-cli/wp-cli:dev-master
   - composer install
   - bash bin/install-package-tests.sh
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,7 @@ dependencies:
     # Increase memory limit
     - echo "memory_limit = 512M" > /opt/circleci/php/$(phpenv global)/etc/conf.d/memory.ini
   override:
+    - composer require wp-cli/wp-cli:dev-master
     - composer install
     - bash bin/install-package-tests.sh
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "files": [ "scaffold-package-command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "dev-master"
+        "wp-cli/wp-cli": "^1.0.0"
     },
     "require-dev": {
         "behat/behat": "~2.5"


### PR DESCRIPTION
Doing so prevents `wp package install` from failing when it runs a
version check

See https://github.com/wp-cli/wp-cli/issues/3933#issuecomment-289932593

From #91