### PR TITLE
Only add commands if `scaffold` is already loaded.

### DIFF
--- a/scaffold-package-command.php
+++ b/scaffold-package-command.php
@@ -4,8 +4,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-WP_CLI::add_hook( 'after_add_command:scaffold', function () {
-
+$registration = function () {
 	$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
 	if ( file_exists( $autoload ) ) {
 		require_once $autoload;
@@ -14,5 +13,11 @@ WP_CLI::add_hook( 'after_add_command:scaffold', function () {
 	WP_CLI::add_command( 'scaffold package', array( 'WP_CLI\ScaffoldPackageCommand', 'package' ) );
 	WP_CLI::add_command( 'scaffold package-readme', array( 'WP_CLI\ScaffoldPackageCommand', 'package_readme' ) );
 	WP_CLI::add_command( 'scaffold package-tests', array( 'WP_CLI\ScaffoldPackageCommand', 'package_tests' ) );
+};
 
-} );
+// Only use command hooks in versions that support them.
+if ( version_compare( WP_CLI_VERSION, '1.2.0-alpha', '>' ) ) {
+	WP_CLI::add_hook( 'after_add_command:scaffold', $registration );
+} else {
+	$registration();
+}

--- a/scaffold-package-command.php
+++ b/scaffold-package-command.php
@@ -16,7 +16,7 @@ $registration = function () {
 };
 
 // Only use command hooks in versions that support them.
-if ( version_compare( WP_CLI_VERSION, '1.2.0-alpha', '>' ) ) {
+if ( version_compare( WP_CLI_VERSION, '1.2.0-alpha', '>=' ) ) {
 	WP_CLI::add_hook( 'after_add_command:scaffold', $registration );
 } else {
 	$registration();

--- a/scaffold-package-command.php
+++ b/scaffold-package-command.php
@@ -4,11 +4,15 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
-}
+WP_CLI::add_hook( 'after_add_command:scaffold', function () {
 
-WP_CLI::add_command( 'scaffold package', array( 'WP_CLI\ScaffoldPackageCommand', 'package' ) );
-WP_CLI::add_command( 'scaffold package-readme', array( 'WP_CLI\ScaffoldPackageCommand', 'package_readme' ) );
-WP_CLI::add_command( 'scaffold package-tests', array( 'WP_CLI\ScaffoldPackageCommand', 'package_tests' ) );
+	$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
+	if ( file_exists( $autoload ) ) {
+		require_once $autoload;
+	}
+
+	WP_CLI::add_command( 'scaffold package', array( 'WP_CLI\ScaffoldPackageCommand', 'package' ) );
+	WP_CLI::add_command( 'scaffold package-readme', array( 'WP_CLI\ScaffoldPackageCommand', 'package_readme' ) );
+	WP_CLI::add_command( 'scaffold package-tests', array( 'WP_CLI\ScaffoldPackageCommand', 'package_tests' ) );
+
+} );


### PR DESCRIPTION
With the new hooks introduced in https://github.com/wp-cli/wp-cli/commit/7fcee0ef61d41a74551e2b2a19c0e3bb578d33a0 , we can now only load the commands if the parent they depend on has already been added.

This is needed because of the added flexibility provided by the bootstrap refactoring.

See https://github.com/wp-cli/wp-cli/pull/3872