### PR TITLE
Have README installing instructions default to Git installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ files include:
 
 Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
 
-Once you've done so, you can install this package with `wp package install wp-cli/scaffold-package-command`.
+Once you've done so, you can install this package with:
+
+    wp package install git@github.com:wp-cli/scaffold-package-command.git
 
 ## Contributing
 

--- a/templates/readme-installing.mustache
+++ b/templates/readme-installing.mustache
@@ -1,3 +1,5 @@
 Installing this package requires WP-CLI {{required_wp_cli_version}} or greater. Update to {{wp_cli_update_to_instructions}}.
 
-Once you've done so, you can install this package with `wp package install {{package_name}}`.
+Once you've done so, you can install this package with:
+
+    wp package install git@github.com:{{package_name}}.git


### PR DESCRIPTION
Because the package index is on indefinite hiatus, Git installation is
an easier way to get started.

Fixes #83