### PR TITLE
Shorten the description for `package-tests`

### DIFF
--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -420,7 +420,7 @@ EOT;
 	}
 
 	/**
-	 * Generate files needed for writing Behat tests for your command.
+	 * Generate files for writing Behat tests for your command.
 	 *
 	 * WP-CLI makes use of a Behat-based testing framework, which you should use
 	 * too. This command generates all of the files you need. Functional tests


### PR DESCRIPTION
Avoids line wrapping in the help screen. Fixes #112.