### PR TITLE
Clarify help text and error messages for invalid <dir> values

### DIFF
--- a/features/scaffold-package-github.feature
+++ b/features/scaffold-package-github.feature
@@ -1,13 +1,25 @@
 Feature: Scaffold GitHub configuration for an existing package
 
-  Scenario: Fails when invalid package directory provided
+  Scenario: Fails when invalid directory provided
     Given an empty directory
 
-    When I run `wp package path`
-    Then save STDOUT as {PACKAGE_PATH}
+    When I try `wp scaffold package-github bar`
+    Then the bar directory should not exist
+    And STDERR should be:
+      """
+      Error: Directory does not exist.
+      """
 
-    When I try `wp scaffold package-github {PACKAGE_PATH}/local/wp-cli/default-github`
-    Then STDERR should be:
+  Scenario: Fails when invalid package provided
+    Given an empty directory
+    And a baz/empty file:
+      """
+      """
+
+    When I try `wp scaffold package-github baz`
+    Then the baz directory should exist
+    But the baz/.github directory should not exist
+    And STDERR should be:
       """
       Error: Invalid package directory. composer.json file must be present.
       """

--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -1,5 +1,29 @@
 Feature: Scaffold a README.md file for an existing package
 
+  Scenario: Fails when invalid directory provided
+    Given an empty directory
+
+    When I try `wp scaffold package-readme bar`
+    Then the bar directory should not exist
+    And STDERR should be:
+      """
+      Error: Directory does not exist.
+      """
+
+  Scenario: Fails when invalid package provided
+    Given an empty directory
+    And a baz/empty file:
+      """
+      """
+
+    When I try `wp scaffold package-readme baz`
+    Then the baz directory should exist
+    But the baz/README.md file should not exist
+    And STDERR should be:
+      """
+      Error: Invalid package directory. composer.json file must be present.
+      """
+
   Scenario: Scaffold a README.md based on the defaults
     Given an empty directory
 

--- a/features/scaffold-package-tests.feature
+++ b/features/scaffold-package-tests.feature
@@ -24,6 +24,30 @@ Feature: Scaffold the test suite for an existing package
       }
       """
 
+  Scenario: Fails when invalid directory provided
+    Given an empty directory
+
+    When I try `wp scaffold package-tests bar`
+    Then the bar directory should not exist
+    And STDERR should be:
+      """
+      Error: Directory does not exist.
+      """
+
+  Scenario: Fails when invalid package provided
+    Given an empty directory
+    And a baz/empty file:
+      """
+      """
+
+    When I try `wp scaffold package-tests baz`
+    Then the baz directory should exist
+    But the baz/features directory should not exist
+    And STDERR should be:
+      """
+      Error: Invalid package directory. composer.json file must be present.
+      """
+
   Scenario: Scaffold package tests
     Given a invalid-command/command.php file:
       """

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -182,7 +182,7 @@ EOT;
 	 * ## OPTIONS
 	 *
 	 * <dir>
-	 * : Directory of an existing command.
+	 * : Directory path to an existing package to generate a readme for.
 	 *
 	 * [--force]
 	 * : Overwrite the readme if it already exists.
@@ -384,7 +384,7 @@ EOT;
 	 * ## OPTIONS
 	 *
 	 * <dir>
-	 * : The package directory to generate GitHub configuration for.
+	 * : Directory path to an existing package to generate GitHub configuration for.
 	 *
 	 * [--force]
 	 * : Overwrite files that already exist.
@@ -492,7 +492,7 @@ EOT;
 	 * ## OPTIONS
 	 *
 	 * <dir>
-	 * : The package directory to generate tests for.
+	 * : Directory path to an existing package to generate tests for.
 	 *
 	 * [--ci=<provider>]
 	 * : Create a configuration file for a specific CI provider.

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -194,13 +194,7 @@ EOT;
 
 		list( $package_dir ) = $args;
 
-		if ( ! is_dir( $package_dir ) ) {
-			WP_CLI::error( 'Directory does not exist.' );
-		}
-
-		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
-			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
-		}
+		self::check_if_valid_package_dir( $package_dir );
 
 		$composer_obj = json_decode( file_get_contents( $package_dir . '/composer.json' ), true );
 		if ( ! $composer_obj ) {
@@ -405,13 +399,7 @@ EOT;
 			$package_dir = rtrim( $package_dir, '/' );
 		}
 
-		if ( ! is_dir( $package_dir ) ) {
-			WP_CLI::error( 'Directory does not exist.' );
-		}
-
-		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
-			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
-		}
+		self::check_if_valid_package_dir( $package_dir );
 
 		$force = Utils\get_flag_value( $assoc_args, 'force' );
 		$template_path = dirname( dirname( __FILE__ ) ) . '/templates';
@@ -531,13 +519,7 @@ EOT;
 			$package_dir = rtrim( $package_dir, '/' );
 		}
 
-		if ( ! is_dir( $package_dir ) ) {
-			WP_CLI::error( 'Directory does not exist.' );
-		}
-
-		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
-			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
-		}
+		self::check_if_valid_package_dir( $package_dir );
 
 		$package_dir .= '/';
 		$bin_dir       = $package_dir . 'bin/';
@@ -675,6 +657,16 @@ EOT;
 			}
 		}
 		return $wrote_files;
+	}
+
+	private static function check_if_valid_package_dir( $package_dir ) {
+		if ( ! is_dir( $package_dir ) ) {
+			WP_CLI::error( 'Directory does not exist.' );
+		}
+
+		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
+			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
+		}
 	}
 
 }

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -194,8 +194,12 @@ EOT;
 
 		list( $package_dir ) = $args;
 
-		if ( ! is_dir( $package_dir ) || ! file_exists( $package_dir . '/composer.json' ) ) {
-			WP_CLI::error( "Invalid package directory. composer.json file must be present." );
+		if ( ! is_dir( $package_dir ) ) {
+			WP_CLI::error( 'Directory does not exist.' );
+		}
+
+		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
+			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
 		}
 
 		$composer_obj = json_decode( file_get_contents( $package_dir . '/composer.json' ), true );
@@ -401,9 +405,14 @@ EOT;
 			$package_dir = rtrim( $package_dir, '/' );
 		}
 
-		if ( ! is_dir( $package_dir ) || ! file_exists( $package_dir . '/composer.json' ) ) {
-			WP_CLI::error( "Invalid package directory. composer.json file must be present." );
+		if ( ! is_dir( $package_dir ) ) {
+			WP_CLI::error( 'Directory does not exist.' );
 		}
+
+		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
+			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
+		}
+
 		$force = Utils\get_flag_value( $assoc_args, 'force' );
 		$template_path = dirname( dirname( __FILE__ ) ) . '/templates';
 
@@ -522,8 +531,12 @@ EOT;
 			$package_dir = rtrim( $package_dir, '/' );
 		}
 
-		if ( ! is_dir( $package_dir ) || ! file_exists( $package_dir . '/composer.json' ) ) {
-			WP_CLI::error( "Invalid package directory. composer.json file must be present." );
+		if ( ! is_dir( $package_dir ) ) {
+			WP_CLI::error( 'Directory does not exist.' );
+		}
+
+		if ( ! file_exists( $package_dir . '/composer.json' ) ) {
+			WP_CLI::error( 'Invalid package directory. composer.json file must be present.' );
 		}
 
 		$package_dir .= '/';


### PR DESCRIPTION
This improves the help text and adds clearer error messages relating to the `<dir>` flag.