### PR TITLE
Add a `--skip-install` flag to package scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package implements the following commands:
 Generate the files needed for a basic WP-CLI command.
 
 ~~~
-wp scaffold package <name> [--description=<description>] [--homepage=<homepage>] [--dir=<dir>] [--license=<license>] [--require_wp_cli=<version>] [--skip-tests] [--skip-readme] [--force]
+wp scaffold package <name> [--description=<description>] [--homepage=<homepage>] [--dir=<dir>] [--license=<license>] [--require_wp_cli=<version>] [--skip-tests] [--skip-readme] [--skip-install] [--force]
 ~~~
 
 Default behavior is to create the following files:
@@ -60,6 +60,9 @@ WP-CLI `packages/local/` directory.
 
 	[--skip-readme]
 		Don't generate a README.md for the package.
+
+	[--skip-install]
+		Don't install the package after scaffolding.
 
 	[--force]
 		Overwrite files that already exist.

--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -230,3 +230,16 @@ Feature: Scaffold WP-CLI commands
       Success: Package installed.
       """
     And the /tmp/wp-cli-home/foo directory should exist
+
+  Scenario: Scaffold a package but skip installation
+    Given an empty directory
+
+    When I run `wp scaffold package wp-cli/foo --skip-install`
+    Then STDOUT should contain:
+      """
+      Success: Created package files
+      """
+    And STDOUT should not contain:
+      """
+      Installing package
+      """

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -53,6 +53,9 @@ class ScaffoldPackageCommand {
 	 * [--skip-readme]
 	 * : Don't generate a README.md for the package.
 	 *
+	 * [--skip-install]
+	 * : Don't install the package after scaffolding.
+	 *
 	 * [--force]
 	 * : Overwrite files that already exist.
 	 *
@@ -121,7 +124,9 @@ EOT;
 			WP_CLI::runcommand( "scaffold package-readme {$package_dir} {$force_flag}", array( 'launch' => false ) );
 		}
 
-		WP_CLI::runcommand( "package install {$package_dir}", array( 'launch' => false ) );
+		if ( ! Utils\get_flag_value( $assoc_args, 'skip-install' ) ) {
+			WP_CLI::runcommand( "package install {$package_dir}", array( 'launch' => false ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
If the package is already installed, you may not want to install it
again when running scaffolding a second time.