### PR TITLE
cache the wp to the specific directory

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -75,14 +75,13 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	// We cache the results of `wp core download` to improve test performance
 	// Ideally, we'd cache at the HTTP layer for more reliable tests
 	private static function cache_wp_files() {
-		self::$cache_dir = sys_get_temp_dir() . '/wp-cli-test core-download-cache';
-
+		$wp_version_suffix = ( $wp_version = getenv( 'WP_VERSION' ) ) ? "-$wp_version" : '';
+		self::$cache_dir = sys_get_temp_dir() . '/wp-cli-test-core-download-cache' . $wp_version_suffix;
 		if ( is_readable( self::$cache_dir . '/wp-config-sample.php' ) )
 			return;
-
 		$cmd = Utils\esc_cmd( 'wp core download --force --path=%s', self::$cache_dir );
-		if ( getenv( 'WP_VERSION' ) ) {
-			$cmd .= Utils\esc_cmd( ' --version=%s', getenv( 'WP_VERSION' ) );
+		if ( $wp_version ) {
+			$cmd .= Utils\esc_cmd( ' --version=%s', $wp_version );
 		}
 		Process::create( $cmd, null, self::get_process_env_variables() )->run_check();
 	}


### PR DESCRIPTION
It creates separate cache directory for behat to the WP_VERSION specific directory.

Related: https://github.com/wp-cli/wp-cli/pull/4287, https://github.com/wp-cli/wp-cli/issues/4343