### PR TITLE
Add context to behat which can check the contents with regexp

### DIFF
--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -2,6 +2,12 @@
 
 // Utility functions used by Behat steps
 
+function assertRegExp( $regex, $actual ) {
+	if ( ! preg_match( $regex, $actual ) ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
 function assertEquals( $expected, $actual ) {
 	if ( $expected != $actual ) {
 		throw new Exception( "Actual value: " . var_export( $actual, true ) );

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -152,7 +152,7 @@ $steps->Then( '/^(STDOUT|STDERR) should be a version string (<|<=|>|>=|==|=|!=|<
 			throw new Exception( $world->result );
 		}
 	}
-);	
+);
 
 $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
 	function ( $world, $path, $type, $action, $expected = null ) {
@@ -197,6 +197,20 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 			checkString( $contents, $expected, $action );
 		}
 	}
+);
+
+$steps->Then( '/^the (.+) file should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+function ( $world, $path, $expected = null ) {
+	$path = $world->replace_variables( $path );
+
+	// If it's a relative path, make it relative to the current test dir
+	if ( '/' !== $path[0] ) {
+		$path = $world->variables['RUN_DIR'] . "/$path";
+	}
+
+	$contents = file_get_contents( $path );
+	assertRegExp( $expected, $contents );
+}
 );
 
 $steps->Then( '/^an email should (be sent|not be sent)$/', function( $world, $expected ) {

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -199,8 +199,8 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 	}
 );
 
-$steps->Then( '/^the (.+) file should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
-function ( $world, $path, $expected = null ) {
+$steps->Then( '/^the contents of the (.+) file should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+function ( $world, $path, $expected ) {
 	$path = $world->replace_variables( $path );
 
 	// If it's a relative path, make it relative to the current test dir
@@ -210,6 +210,14 @@ function ( $world, $path, $expected = null ) {
 
 	$contents = file_get_contents( $path );
 	assertRegExp( $expected, $contents );
+}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+function ( $world, $stream, $expected ) {
+
+	$stream = strtolower( $stream );
+	assertRegExp( $expected, $world->result->$stream );
 }
 );
 


### PR DESCRIPTION
I added the new context to behat which can check the file contents with regex like following.

```
When I run `echo "hello" > hello.txt`
Then the hello.txt file should match /^H.+o$/i
```

Related:
https://github.com/wp-cli/scaffold-command/pull/61#discussion_r143706183