### PR TITLE
Add second required `wp_cli_test_scaffold` database to source of truth

### DIFF
--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -5,6 +5,7 @@ set -ex
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
 install_db


### PR DESCRIPTION
Because all packages are scaffolded from this copy of
`bin/install-package-tests.sh`, the database creation definition needs
to be included in this bash script.