### PR TITLE
Scaffold a `.github/settings.yml` with package description and labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,7 +6,7 @@ Please review our contributing guidelines if you haven't recently: https://make.
 
 Here's an overview to our process:
 
-1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
+1. One of the project committers will soon provide a code review.
 2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
 3. Please make sure to include functional tests for your changes.
 4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,22 @@
+# Used by Probot Settings: https://probot.github.io/apps/settings/
+repository:
+  description: Scaffolds WP-CLI commands with functional tests, full README.md, and more.
+  labels:
+    - name: scope:documentation
+      color: 0e8a16
+    - name: scope:testing
+      color: 5319e7
+    - name: good-first-issue
+      color: eb6420
+    - name: state:unconfirmed
+      color: bfe5bf
+    - name: state:unsupported
+      color: bfe5bf
+    - name: command:scaffold-package
+      color: c5def5
+    - name: command:scaffold-package-tests
+      color: c5def5
+    - name: command:scaffold-package-readme
+      color: c5def5
+    - name: command:scaffold-package-github
+      color: c5def5

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/scaffold-package-command
 ===============================
 
-Scaffold WP-CLI commands with functional tests
+Scaffolds WP-CLI commands with functional tests, full README.md, and more.
 
 [![Build Status](https://travis-ci.org/wp-cli/scaffold-package-command.svg?branch=master)](https://travis-ci.org/wp-cli/scaffold-package-command) [![CircleCI](https://circleci.com/gh/wp-cli/scaffold-package-command/tree/master.svg?style=svg)](https://circleci.com/gh/wp-cli/scaffold-package-command/tree/master)
 
@@ -258,6 +258,7 @@ files include:
 
 * `.github/ISSUE_TEMPLATE` - Text displayed when a user opens a new issue.
 * `.github/PULL_REQUEST_TEMPLATE` - Text displayed when a user submits a pull request.
+* `.github/settings.yml` - Configuration file for the [Probot settings app](https://probot.github.io/apps/settings/).
 
 **OPTIONS**
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/scaffold-package-command",
-    "description": "Scaffold WP-CLI commands with functional tests",
+    "description": "Scaffolds WP-CLI commands with functional tests, full README.md, and more.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/scaffold-package-command",
     "support": {

--- a/templates/github-settings.mustache
+++ b/templates/github-settings.mustache
@@ -1,0 +1,12 @@
+# Used by Probot Settings: https://probot.github.io/apps/settings/
+repository:
+{{#has_description}}
+  description: {{description}}
+{{/has_description}}
+{{#has_labels}}
+  labels:
+  {{#labels}}
+    - name: {{name}}
+      color: {{color}}
+  {{/labels}}
+{{/has_labels}}


### PR DESCRIPTION
When this is merged, it should automatically update the respository description.

Requires [Probot Settings app](https://probot.github.io/apps/settings/)

See https://github.com/wp-cli/wp-cli/issues/3857