### PR TITLE
Don't cache the `vendor` directory in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ branches:
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 env:


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/4534