### PR TITLE
Fix GitHub settings label generation; ensure default labels are kept

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,22 +1,30 @@
 # Used by Probot Settings: https://probot.github.io/apps/settings/
 repository:
   description: Scaffolds WP-CLI commands with functional tests, full README.md, and more.
-  labels:
-    - name: scope:documentation
-      color: 0e8a16
-    - name: scope:testing
-      color: 5319e7
-    - name: good-first-issue
-      color: eb6420
-    - name: state:unconfirmed
-      color: bfe5bf
-    - name: state:unsupported
-      color: bfe5bf
-    - name: command:scaffold-package
-      color: c5def5
-    - name: command:scaffold-package-tests
-      color: c5def5
-    - name: command:scaffold-package-readme
-      color: c5def5
-    - name: command:scaffold-package-github
-      color: c5def5
+labels:
+  - name: bug
+    color: fc2929
+  - name: scope:documentation
+    color: 0e8a16
+  - name: scope:testing
+    color: 5319e7
+  - name: good-first-issue
+    color: eb6420
+  - name: help-wanted
+    color: 159818
+  - name: maybelater
+    color: c2e0c6
+  - name: state:unconfirmed
+    color: bfe5bf
+  - name: state:unsupported
+    color: bfe5bf
+  - name: wontfix
+    color: c2e0c6
+  - name: command:scaffold-package
+    color: c5def5
+  - name: command:scaffold-package-tests
+    color: c5def5
+  - name: command:scaffold-package-readme
+    color: c5def5
+  - name: command:scaffold-package-github
+    color: c5def5

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -435,6 +435,10 @@ EOT;
 			'has_labels'      => true,
 			'labels'          => array(
 				array(
+					'name'    => 'bug',
+					'color'   => 'fc2929'
+				),
+				array(
 					'name'    => 'scope:documentation',
 					'color'   => '0e8a16'
 				),
@@ -447,12 +451,24 @@ EOT;
 					'color'   => 'eb6420',
 				),
 				array(
+					'name'    => 'help-wanted',
+					'color'   => '159818',
+				),
+				array(
+					'name'    => 'maybelater',
+					'color'   => 'c2e0c6',
+				),
+				array(
 					'name'    => 'state:unconfirmed',
 					'color'   => 'bfe5bf'
 				),
 				array(
 					'name'    => 'state:unsupported',
 					'color'   => 'bfe5bf'
+				),
+				array(
+					'name'    => 'wontfix',
+					'color'   => 'c2e0c6',
 				),
 			),
 		);

--- a/templates/github-settings.mustache
+++ b/templates/github-settings.mustache
@@ -4,9 +4,9 @@ repository:
   description: {{description}}
 {{/has_description}}
 {{#has_labels}}
-  labels:
-  {{#labels}}
-    - name: {{name}}
-      color: {{color}}
-  {{/labels}}
+labels:
+{{#labels}}
+  - name: {{name}}
+    color: {{color}}
+{{/labels}}
 {{/has_labels}}


### PR DESCRIPTION
Introduced in #154
Format verified in https://github.com/wp-cli/widget-command/commit/c39f0f1a6e90427fa2db693c81c54e4e2f658e74
See https://github.com/wp-cli/wp-cli/issues/3857