### PR TITLE
move wp-cli into require-dev in composer.json

### DIFF
--- a/templates/composer.mustache
+++ b/templates/composer.mustache
@@ -10,10 +10,9 @@
     "autoload": {
         "files": [ "command.php" ]
     },
-    "require": {
-        "wp-cli/wp-cli": "{{require_wp_cli}}"
-    },
+    "require": {},
     "require-dev": {
+        "wp-cli/wp-cli": "{{require_wp_cli}}",
         "behat/behat": "~2.5"
     }
 }


### PR DESCRIPTION
`wp-cli/wp-cli` should be in `require-dev`, right?