### PR TITLE
Add latest version support to behat tags

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -8,6 +8,10 @@ then
 	phpunit
 fi
 
+if [ $WP_VERSION = "latest" ]; then
+	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
+fi
+
 # Run the functional tests
 BEHAT_TAGS=$(php utils/behat-tags.php)
 behat --format progress $BEHAT_TAGS --strict


### PR DESCRIPTION
This is needed to be able to skip tests that fail on trunk.