### PR TITLE
Fix Implode signature

### DIFF
--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -706,7 +706,7 @@ EOT;
 		foreach ( $lines as &$line ) {
 			$line = $whitespace . $line;
 		}
-		return implode( $lines, "\n" );
+		return implode( "\n", $lines );
 	}
 
 	private function prompt_if_files_will_be_overwritten( $filename, $force ) {


### PR DESCRIPTION
The following triggered an error locally...

```
return implode( $lines, "\n" );
```

By switching the operands so that glue comes first and collection second. I believe this might help this to work

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

This addresses a fundamental PHP error in the code. Unsure how this wasn't picked up on sooner.