### PR TITLE
Fix scaffolding paths

### DIFF
--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -625,15 +625,18 @@ EOT;
 		}
 
 		$wp_cli_root = WP_CLI_ROOT;
+		$wp_cli_test_root = realpath(implode(DIRECTORY_SEPARATOR, [WP_CLI_ROOT, '..', 'wp-cli-tests']));
+
 		$package_root = dirname( dirname( __FILE__ ) );
 		$copy_source = array(
 			$wp_cli_root => array(
-				'features/bootstrap/FeatureContext.php'       => $bootstrap_dir,
-				'features/bootstrap/support.php'              => $bootstrap_dir,
 				'php/WP_CLI/Process.php'                      => $bootstrap_dir,
 				'php/WP_CLI/ProcessRun.php'                   => $bootstrap_dir,
 				'php/utils.php'                               => $bootstrap_dir,
-				'ci/behat-tags.php'                           => $utils_dir,
+			),
+			$wp_cli_test_root => array(
+				'features/bootstrap/FeatureContext.php'       => $bootstrap_dir,
+				'features/bootstrap/support.php'              => $bootstrap_dir,
 				'features/steps/given.php'                    => $steps_dir,
 				'features/steps/when.php'                     => $steps_dir,
 				'features/steps/then.php'                     => $steps_dir,
@@ -642,6 +645,7 @@ EOT;
 			$package_root => array(
 				'bin/install-package-tests.sh'                => $bin_dir,
 				'bin/test.sh'                                 => $bin_dir,
+				'utils/behat-tags.php'                        => $utils_dir,
 			),
 		);
 

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -641,11 +641,11 @@ EOT;
 				'features/steps/when.php'                     => $steps_dir,
 				'features/steps/then.php'                     => $steps_dir,
 				'features/extra/no-mail.php'                  => $extra_dir,
+				'utils/behat-tags.php'                        => $utils_dir,
 			),
 			$package_root => array(
 				'bin/install-package-tests.sh'                => $bin_dir,
 				'bin/test.sh'                                 => $bin_dir,
-				'utils/behat-tags.php'                        => $utils_dir,
 			),
 		);
 

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -625,7 +625,7 @@ EOT;
 		}
 
 		$wp_cli_root = WP_CLI_ROOT;
-		$wp_cli_test_root = realpath(implode(DIRECTORY_SEPARATOR, [WP_CLI_ROOT, '..', 'wp-cli-tests']));
+		$wp_cli_test_root = WP_CLI_ROOT . '/../wp-cli-tests';
 
 		$package_root = dirname( dirname( __FILE__ ) );
 		$copy_source = array(


### PR DESCRIPTION
Fixes #188 

Approach:

Modify the file-paths copied

notation: source -> dest (vendor path omitted)

* `wp-cli/wp-cli/ci/behat-tags.php` -> `./utils/behat-tags.php`
* `wp-cli/wp-cli/features/bootstrap/FeatureContext.php` -> `wp-cli/wp-cli-tests/features/bootstrap/FeatureContext.php`
* `wp-cli/wp-cli/features/bootstrap/support.php` -> `wp-cli/wp-cli-tests/features/bootstrap/support.php`
* `wp-cli/wp-cli/features/steps/given.php` -> `wp-cli/wp-cli-tests/features/steps/given.php`
* `wp-cli/wp-cli/features/steps/when.php` -> `wp-cli/wp-cli-tests/features/steps/when.php`
* `wp-cli/wp-cli/features/steps/then.php` -> `wp-cli/wp-cli-tests/features/steps/then.php`
* `wp-cli/wp-cli/features/extra/no-mail.php` -> `wp-cli/wp-cli-tests/features/extra/no-mail.php`

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

**Note:** Takes passing Travis-CI tests from 49 -> 51 with no new errors (that I've noticed, it's all still some composer version error)
