### PR TITLE
fix: circleci pin to stable debian distro & its mariadb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ jobs:
     working_directory: ~/wp-cli/package-tests
     parallelism: 1
     docker:
-    - image: circleci/php:7.4
+    - image: circleci/php:7.4-bullseye
       environment:
         WP_CLI_TEST_DBHOST: 127.0.0.1:3306
         WP_CLI_TEST_DBROOTPASS: root
         WP_CLI_TEST_DBUSER: wp_cli_test
         WP_CLI_TEST_DBPASS: password1
-    - image: circleci/mariadb:10.6
+    - image: circleci/mariadb:10.5
       environment:
         MYSQL_ROOT_PASSWORD: root
         MYSQL_DATABASE: wp_cli_test
@@ -19,10 +19,10 @@ jobs:
     steps:
     - checkout
     - run: |
-        sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+        sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian bullseye main\n' >> /etc/apt/sources.list"
         sudo apt-get update
         sudo docker-php-ext-install mysqli
-        sudo apt-get install mariadb-client-10.6
+        sudo apt-get install mariadb-client
     - run: |
         echo -e "memory_limit = 1024M" | sudo tee /usr/local/etc/php/php.ini > /dev/null
     - run: |


### PR DESCRIPTION
Just look at #190 latest comments

- Prior this was pinned to sid, which is debian `experimental` and does not enjoy the stability.
- It looks like there was a narrow time window when mariadb-client-10.6 was available
  - [archive.org 2021 (1) no package](https://web.archive.org/web/20210204055734/https://packages.debian.org/sid/database/)
  - [archive.org 2021 (2) package](https://web.archive.org/web/20211128124207/https://packages.debian.org/sid/database/)
  - [live package index](https://packages.debian.org/sid/database/mariadb-client)

Decided to install bullseye mariadb-client, which is 10.5 so I rolled back mariadb (it's likely WordPress isn't using advanced enough functionality to care)

worth a note that more work is needed anyway:
[circleci warns image is deprecated as they now have circleci 2.0 images](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) lol 😆 