### PR TITLE
Fix typo in package-readme command doc

### DIFF
--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -217,7 +217,7 @@ EOT;
 	 * : Overwrite the readme if it already exists.
 	 *
 	 * [--branch=<branch>]
-	 * : Name of default branch of the underlaying repository. Defaults to master.
+	 * : Name of default branch of the underlying repository. Defaults to master.
 	 *
 	 * @when before_wp_load
 	 * @subcommand package-readme


### PR DESCRIPTION
**Path:** `src/ScaffoldPackageCommand.php` L220

**Current:**

`underlaying`

**Changed to:**

`underlying`