### PR TITLE
Add featured commands in readme

### DIFF
--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -248,6 +248,7 @@ EOT;
 			'required_wp_cli_version'       => ! empty( $composer_obj['require']['wp-cli/wp-cli'] ) ? str_replace( [ '~', '^', '>=' ], 'v', $composer_obj['require']['wp-cli/wp-cli'] ) : 'v1.3.0',
 			'shields'                       => '',
 			'has_commands'                  => false,
+			'has_featured_commands'         => false,
 			'wp_cli_update_to_instructions' => 'the latest stable release with `wp cli update`',
 			'show_powered_by'               => isset( $composer_obj['extra']['readme']['show_powered_by'] ) ? (bool) $composer_obj['extra']['readme']['show_powered_by'] : true,
 		];
@@ -331,6 +332,18 @@ EOT;
 			}
 			$readme_args['has_commands']          = true;
 			$readme_args['has_multiple_commands'] = count( $readme_args['commands'] ) > 1;
+		}
+
+		$readme_args['featured_commands'] = [];
+
+		if ( ! empty( $composer_obj['extra']['featured-commands'] ) ) {
+			foreach ( $composer_obj['extra']['featured-commands'] as $command ) {
+				$readme_args['featured_commands'][] = [
+					'title' => "wp {$command}",
+					'url'   => '#' . str_replace( ' ', '-', "wp {$command}" ),
+				];
+			}
+			$readme_args['has_featured_commands'] = true;
 		}
 
 		if ( isset( $composer_obj['extra']['readme']['sections'] ) ) {

--- a/templates/readme-using.mustache
+++ b/templates/readme-using.mustache
@@ -1,4 +1,13 @@
 {{#has_commands}}
+{{#has_featured_commands}}
+
+**Featured Commands:**
+
+{{#featured_commands}}
+- [{{title}}]({{url}})
+{{/featured_commands}}
+
+{{/has_featured_commands}}
 {{#has_multiple_commands}}
 
 This package implements the following commands:


### PR DESCRIPTION
Fixes https://github.com/wp-cli/scaffold-package-command/issues/227

* This will read commands from `extra.featured-commands` from `composer.json` and add anchored links in the Using section in the README file.

Note: I could not find a way to add feature test for this as commands are not returned in Behat test currently.