### PR TITLE
Fix scaffold package tests command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,11 @@ WP-CLI Behat framework uses Behat ~2.5, which is installed with Composer.
 	[--force]
 		Overwrite files that already exist.
 
-**EXAMPLE**
+**EXAMPLES**
 
-    wp scaffold package-tests /path/to/command/dir/
+    # Generate files for writing Behat tests.
+    $ wp scaffold package-tests /path/to/command/dir/
+    Success: Created package test files.
 
 
 

--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -626,9 +626,11 @@ EOT;
 	 * [--force]
 	 * : Overwrite files that already exist.
 	 *
-	 * ## EXAMPLE
+	 * ## EXAMPLES
 	 *
-	 *     wp scaffold package-tests /path/to/command/dir/
+	 *     # Generate files for writing Behat tests.
+	 *     $ wp scaffold package-tests /path/to/command/dir/
+	 *     Success: Created package test files.
 	 *
 	 * @when       before_wp_load
 	 * @subcommand package-tests


### PR DESCRIPTION
We use `## EXAMPLES` for examples section in the doc. Fixed scaffold package-tests command where `## EXAMPLE` was used.