### PR TITLE
Switch up CircleCI dependencies to get tests running again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,37 +4,37 @@ jobs:
     working_directory: ~/wp-cli/package-tests
     parallelism: 1
     docker:
-    - image: circleci/php:7.4
-      environment:
-        WP_CLI_TEST_DBHOST: 127.0.0.1:3306
-        WP_CLI_TEST_DBROOTPASS: root
-        WP_CLI_TEST_DBUSER: wp_cli_test
-        WP_CLI_TEST_DBPASS: password1
-    - image: circleci/mariadb:10.6
-      environment:
-        MYSQL_ROOT_PASSWORD: root
-        MYSQL_DATABASE: wp_cli_test
-        MYSQL_USER: wp_cli_test
-        MYSQL_PASSWORD: password1
+      - image: circleci/php:7.4-bullseye
+        environment:
+          WP_CLI_TEST_DBHOST: 127.0.0.1:3306
+          WP_CLI_TEST_DBROOTPASS: root
+          WP_CLI_TEST_DBUSER: wp_cli_test
+          WP_CLI_TEST_DBPASS: password1
+      - image: circleci/mariadb:10.5
+        environment:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wp_cli_test
+          MYSQL_USER: wp_cli_test
+          MYSQL_PASSWORD: password1
     steps:
-    - checkout
-    - run: |
-        sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-        sudo apt-get update
-        sudo docker-php-ext-install mysqli
-        sudo apt-get install mariadb-client-10.6
-    - run: |
-        echo -e "memory_limit = 1024M" | sudo tee /usr/local/etc/php/php.ini > /dev/null
-    - run: |
-        dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
-    - run: |
-        composer validate
-        composer install
-        composer prepare-tests
-    - run: |
-        echo 'export PATH=$HOME/wp-cli/package-tests/vendor/bin:$PATH' >> $BASH_ENV
-        source $BASH_ENV
-    - run: |
-        WP_VERSION=latest composer test
-        rm -rf '/tmp/wp-cli-test core-download-cache'
-        WP_VERSION=trunk composer test
+      - checkout
+      - run: |
+          sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian bullseye main\n' >> /etc/apt/sources.list"
+          sudo apt-get update
+          sudo docker-php-ext-install mysqli
+          sudo apt-get install mariadb-client
+      - run: |
+          echo -e "memory_limit = 1024M" | sudo tee /usr/local/etc/php/php.ini > /dev/null
+      - run: |
+          dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
+      - run: |
+          composer validate
+          composer install
+          composer prepare-tests
+      - run: |
+          echo 'export PATH=$HOME/wp-cli/package-tests/vendor/bin:$PATH' >> $BASH_ENV
+          source $BASH_ENV
+      - run: |
+          WP_VERSION=latest composer test
+          rm -rf '/tmp/wp-cli-test core-download-cache'
+          WP_VERSION=trunk composer test


### PR DESCRIPTION
From https://github.com/wp-cli/scaffold-package-command/pull/224
Fixes https://github.com/wp-cli/scaffold-package-command/issues/190