### PR TITLE
Add phpcbf composer script in scaffolded composer file

### DIFF
--- a/templates/composer.mustache
+++ b/templates/composer.mustache
@@ -42,6 +42,7 @@
         "behat-rerun": "rerun-behat-tests",
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",
+        "phpcbf": "run-phpcbf-cleanup",
         "phpunit": "run-php-unit-tests",
         "prepare-tests": "install-package-tests",
         "test": [


### PR DESCRIPTION
Fixes https://github.com/wp-cli/scaffold-package-command/issues/236

* Add `"phpcbf": "run-phpcbf-cleanup",` in scaffolded `composer.json`