### PR TITLE
Update templated requirements to current releases

### DIFF
--- a/src/ScaffoldPackageCommand.php
+++ b/src/ScaffoldPackageCommand.php
@@ -43,13 +43,13 @@ class ScaffoldPackageCommand {
 	 * [--require_wp_cli=<version>]
 	 * : Required WP-CLI version for the package.
 	 * ---
-	 * default: ^2.5
+	 * default: ^2.10.0
 	 * ---
 	 *
 	 * [--require_wp_cli_tests=<version>]
 	 * : Required WP-CLI testing framework version for the package.
 	 * ---
-	 * default: ^3.0.11
+	 * default: ^4.3.1
 	 * ---
 
 	 * [--skip-tests]


### PR DESCRIPTION
`scaffold-package-command` generates a `composer.json` using relatively old package versions.

https://github.com/wp-cli/scaffold-package-command/blob/c309cf58b5dee0428fa05c45dbf094bb7c2c5c6f/templates/composer.mustache#L8-L13

This PR updates the defaults provided in the PhpDoc to the current releases:

* [wp-cli/wp-cli](https://github.com/wp-cli/wp-cli/releases) current is [v2.10.0](https://github.com/wp-cli/wp-cli/releases/tag/v2.10.0)
* [wp-cli/wp-cli-tests](https://github.com/wp-cli/wp-cli-tests/releases) current release is [v4.3.1](https://github.com/wp-cli/wp-cli-tests/releases/tag/v4.3.1)
