### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,8 +5,8 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	For help understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	For help using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage
 	#############################################################################
 	-->
 

--- a/templates/phpcs.xml.dist.mustache
+++ b/templates/phpcs.xml.dist.mustache
@@ -5,8 +5,8 @@
 	<!--
 	#############################################################################
 	COMMAND LINE ARGUMENTS
-	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	For help understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	For help using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage
 	#############################################################################
 	-->
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932