### PR TITLE
Update generated support links

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -6,7 +6,7 @@ Found a bug or want to suggest an enhancement? Before completing your issue, ple
 
 Have an idea for something new? Jump into the ideas repo: https://github.com/wp-cli/ideas
 
-Need help with something? GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+Need help with something? GitHub issues aren't for general support questions. For support resources and next steps, see the WP-CLI Support page: https://make.wordpress.org/cli/handbook/support/
 
 You can safely delete this comment.
 

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -6,7 +6,7 @@ Found a bug or want to suggest an enhancement? Before completing your issue, ple
 
 Have an idea for something new? Jump into the ideas repo: https://github.com/wp-cli/ideas
 
-Need help with something? GitHub issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
+Need help with something? GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
 
 You can safely delete this comment.
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Support
 
-GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+GitHub issues aren't for general support questions. For support resources and next steps, see the WP-CLI Support page: https://make.wordpress.org/cli/handbook/support/
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Support
 
-GitHub issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
+GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -52,7 +52,7 @@ Feature: Scaffold a README.md file for an existing package
       """
     And the {PACKAGE_PATH}/local/wp-cli/default-readme/README.md file should contain:
       """
-      For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+      For support resources and next steps, see the WP-CLI Support page: https://make.wordpress.org/cli/handbook/support/
       """
     And the {PACKAGE_PATH}/local/wp-cli/default-readme/README.md file should contain:
       """

--- a/features/scaffold-package-readme.feature
+++ b/features/scaffold-package-readme.feature
@@ -52,6 +52,10 @@ Feature: Scaffold a README.md file for an existing package
       """
     And the {PACKAGE_PATH}/local/wp-cli/default-readme/README.md file should contain:
       """
+      For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+      """
+    And the {PACKAGE_PATH}/local/wp-cli/default-readme/README.md file should contain:
+      """
       wp package install wp-cli/default-readme:dev-main
       """
     When I run `wp package uninstall wp-cli/default-readme`

--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -67,7 +67,7 @@ Feature: Scaffold WP-CLI commands
     And the {PACKAGE_PATH}/local/wp-cli/foo/.github/ISSUE_TEMPLATE file should exist
     And the {PACKAGE_PATH}/local/wp-cli/foo/.github/ISSUE_TEMPLATE file should contain:
       """
-      For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+      For support resources and next steps, see the WP-CLI Support page: https://make.wordpress.org/cli/handbook/support/
       """
 
     When I run `wp hello-world`

--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -65,6 +65,10 @@ Feature: Scaffold WP-CLI commands
     And the {PACKAGE_PATH}/local/wp-cli/foo/.travis.yml file should not exist
     And the {PACKAGE_PATH}/local/wp-cli/foo/.github/PULL_REQUEST_TEMPLATE file should exist
     And the {PACKAGE_PATH}/local/wp-cli/foo/.github/ISSUE_TEMPLATE file should exist
+    And the {PACKAGE_PATH}/local/wp-cli/foo/.github/ISSUE_TEMPLATE file should contain:
+      """
+      For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+      """
 
     When I run `wp hello-world`
     Then STDOUT should be:

--- a/templates/github-issue-template.mustache
+++ b/templates/github-issue-template.mustache
@@ -4,7 +4,7 @@ Thanks for creating a new issue!
 
 Found a bug or want to suggest an enhancement? Before completing your issue, please review our best practices: https://make.wordpress.org/cli/handbook/bug-reports/
 
-Need help with something? GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+Need help with something? GitHub issues aren't for general support questions. For support resources and next steps, see the WP-CLI Support page: https://make.wordpress.org/cli/handbook/support/
 
 You can safely delete this comment.
 

--- a/templates/github-issue-template.mustache
+++ b/templates/github-issue-template.mustache
@@ -4,7 +4,7 @@ Thanks for creating a new issue!
 
 Found a bug or want to suggest an enhancement? Before completing your issue, please review our best practices: https://make.wordpress.org/cli/handbook/bug-reports/
 
-Need help with something? GitHub issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
+Need help with something? GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
 
 You can safely delete this comment.
 

--- a/templates/readme-support.mustache
+++ b/templates/readme-support.mustache
@@ -1,1 +1,1 @@
-GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/
+GitHub issues aren't for general support questions. For support resources and next steps, see the WP-CLI Support page: https://make.wordpress.org/cli/handbook/support/

--- a/templates/readme-support.mustache
+++ b/templates/readme-support.mustache
@@ -1,1 +1,1 @@
-GitHub issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
+GitHub issues aren't for general support questions. For help with common problems, see the WP-CLI common issues guide: https://make.wordpress.org/cli/handbook/guides/common-issues/


### PR DESCRIPTION
## Summary

Updates the support link used in generated package files.

The old `wp-cli.org/#support` link now redirects to the general WordPress.org CLI page, so this points people to the WP-CLI common issues guide instead.

## Changes

- Update the README support template.
- Update the generated GitHub issue template.
- Update this repo's generated README and issue template copy.
- Add small Behat checks for the generated README and issue template text.

## Verification

- Ran `composer lint`.
- Ran `composer phpcs`.
- Ran `composer phpstan`.
- Confirmed generated README output uses the new support link.
- Confirmed generated issue template output uses the new support link.